### PR TITLE
Center align hashcat and john results

### DIFF
--- a/src/Components/Results.js
+++ b/src/Components/Results.js
@@ -98,8 +98,8 @@ const Row = (props) => {
         <TableCell component="th" scope="row">
           {row.name}
         </TableCell>
-        <TableCell align="right">{row.hashcat}</TableCell>
-        <TableCell align="right">{row.john}</TableCell>
+        <TableCell align="center">{row.hashcat}</TableCell>
+        <TableCell align="center">{row.john}</TableCell>
       </StyledTableRow>
       <TableRow>
         <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>


### PR DESCRIPTION
The "name" values are centered, but "hashcat" and "john" values are right aligned which is inconsistent.
(I wasn't able to test this due to network error? So this was eyeballed)